### PR TITLE
Replace 1rpc rpcs

### DIFF
--- a/registry
+++ b/registry
@@ -1,5 +1,5 @@
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/fb7664a319f957dd8cdbae55c1b0a8bca0926c02/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/fb7664a319f957dd8cdbae55c1b0a8bca0926c02/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/fb7664a319f957dd8cdbae55c1b0a8bca0926c02/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/fb7664a319f957dd8cdbae55c1b0a8bca0926c02/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/fb7664a319f957dd8cdbae55c1b0a8bca0926c02/src/canary.rain
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/b0703df4179caa96f217fc0a03b463e29d67c262/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/b0703df4179caa96f217fc0a03b463e29d67c262/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/b0703df4179caa96f217fc0a03b463e29d67c262/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/b0703df4179caa96f217fc0a03b463e29d67c262/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/b0703df4179caa96f217fc0a03b463e29d67c262/src/canary.rain

--- a/settings.json
+++ b/settings.json
@@ -25,7 +25,7 @@
 			"currency": "ETH"
 		},
 		"arbitrum2": {
-			"rpc": "https://1rpc.io/arb",
+			"rpc": "https://arbitrum-one-rpc.publicnode.com",
 			"chain-id": 42161,
 			"network-id": 42161,
 			"currency": "ETH"
@@ -91,8 +91,8 @@
 		},
 		"arbitrum2": {
 			"address": "0x59401C9302E79Eb8AC6aea659B8B3ae475715e86",
-			"network": "arbitrum",
-			"subgraph": "arbitrum-2"
+			"network": "arbitrum2",
+			"subgraph": "arbitrum2"
 		},
 		"matchain": {
 			"address": "0x40312edab8fe65091354172ad79e9459f21094e2",

--- a/settings.json
+++ b/settings.json
@@ -13,13 +13,13 @@
 			"currency": "ETH"
 		},
 		"polygon": {
-			"rpc": "https://1rpc.io/matic",
+			"rpc": "https://polygon-rpc.com",
 			"chain-id": 137,
 			"network-id": 137,
 			"currency": "POL"
 		},
 		"arbitrum": {
-			"rpc": "https://1rpc.io/arb",
+			"rpc": "https://arbitrum-one-rpc.publicnode.com",
 			"chain-id": 42161,
 			"network-id": 42161,
 			"currency": "ETH"
@@ -37,7 +37,7 @@
 			"currency": "ETH"
 		},
 		"ethereum": {
-			"rpc": "https://1rpc.io/eth",
+			"rpc": "https://ethereum-rpc.publicnode.com",
 			"chain-id": 1,
 			"network-id": 1,
 			"currency": "ETH"

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,12 +9,12 @@ networks:
     network-id: 8453
     currency: ETH
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL
   arbitrum:
-    rpc: https://1rpc.io/arb
+    rpc: https://arbitrum-one-rpc.publicnode.com
     chain-id: 42161
     network-id: 42161
     currency: ETH
@@ -29,7 +29,7 @@ networks:
     network-id: 59144
     currency: ETH
   ethereum:
-    rpc: https://1rpc.io/eth
+    rpc: https://ethereum-rpc.publicnode.com
     chain-id: 1
     network-id: 1
     currency: ETH

--- a/src/auction-dca.rain
+++ b/src/auction-dca.rain
@@ -6,6 +6,11 @@ networks:
     chain-id: 42161
     network-id: 42161
     currency: ETH
+  arbitrum2:
+    rpc: https://arbitrum-one-rpc.publicnode.com
+    chain-id: 42161
+    network-id: 42161
+    currency: ETH
   bsc:
     rpc: https://bsc-dataseed.bnbchain.org
     chain-id: 56
@@ -34,6 +39,7 @@ networks:
 
 subgraphs:
   arbitrum: https://example.com/subgraph
+  arbitrum2: https://example.com/subgraph
   bsc: https://example.com/subgraph
   base: https://example.com/subgraph
   ethereum: https://example.com/subgraph
@@ -42,6 +48,7 @@ subgraphs:
 
 metaboards:
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
+  arbitrum2: https://example.com/subgraph
   bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base/0.1/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
@@ -51,6 +58,8 @@ metaboards:
 orderbooks:
   arbitrum:
     address: 0x550878091b2B1506069F61ae59e3A5484Bca9166
+  arbitrum2:
+    address: 0x59401C9302E79Eb8AC6aea659B8B3ae475715e86
   bsc:
     address: 0xd2938E7c9fe3597F78832CE780Feb61945c377d7
   base:
@@ -64,6 +73,8 @@ orderbooks:
 
 deployers:
   arbitrum:
+    address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
+  arbitrum2:
     address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
   bsc:
     address: 0xA2f56F8F74B7d04d61f281BE6576b6155581dcBA
@@ -89,6 +100,12 @@ tokens:
 orders:
   arbitrum:
     orderbook: arbitrum
+    inputs:
+      - token: input
+    outputs:
+      - token: output
+  arbitrum2:
+    orderbook: arbitrum2
     inputs:
       - token: input
     outputs:
@@ -139,6 +156,15 @@ orders:
 scenarios:
   arbitrum:
     orderbook: arbitrum
+    runs: 1
+    bindings:
+      raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
+      subparser-0: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
+      baseline-fn: '''constant-baseline'
+      initial-io-fn: '''constant-initial-io'
+      shy-epoch: 0.05
+  arbitrum2:
+    orderbook: arbitrum2
     runs: 1
     bindings:
       raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
@@ -218,6 +244,9 @@ deployments:
   arbitrum:
     order: arbitrum
     scenario: arbitrum
+  arbitrum2:
+    order: arbitrum2
+    scenario: arbitrum2
   polygon:
     order: polygon
     scenario: polygon
@@ -373,7 +402,133 @@ gui:
           name: Token to Buy
           description: Select the token you want to purchase
         
+    arbitrum2:
+      name: Arbitrum
+      description: Deploy an auction-based cost averaging strategy on Arbitrum.
+      deposits:
+        - token: output
+      fields:
+        - binding: time-per-amount-epoch
+          name: Budget period (in seconds)
+          description: |
+            The budget is spent over this time period.
 
+            For example, if the budget is daily then this is 86400 seconds (24 * 60 * 60).
+          show-custom-field: true
+          presets:
+            - name: Per minute (60)
+              value: 60
+            - name: Per hour (3600)
+              value: 3600
+            - name: Per day (86400)
+              value: 86400
+            - name: Per week (604800)
+              value: 604800
+            - name: Per 30 days (2592000)
+              value: 2592000
+            - name: Per 365 days (31536000)
+              value: 31536000
+        - binding: amount-per-epoch
+          name: Budget (${order.outputs.0.token.symbol} per period)
+          description: |
+            The amount of ${order.outputs.0.token.symbol} to spend each budget period.
+
+            For example, if the budget is daily and this is 10 then 10 ${order.outputs.0.token.symbol} will be sold for ${order.inputs.0.token.symbol} each day.
+        - binding: max-trade-amount
+          name: Maximum trade size (${order.outputs.0.token.symbol})
+          description: |
+            The maximum amount of ${order.outputs.0.token.symbol} to sell in a single auction.
+        - binding: min-trade-amount
+          name: Minimum trade size (${order.outputs.0.token.symbol})
+          description: |
+            The minimum amount of ${order.outputs.0.token.symbol} to sell in a single auction.
+        - binding: time-per-trade-epoch
+          name: Auction period (in seconds)
+          description: |
+            The auction period is the time between each auction price halvening.
+          show-custom-field: true
+          default: 3600
+          presets:
+            - name: Every 20 minutes (1200)
+              value: 1200
+            - name: Every 30 minutes (1800)
+              value: 1800
+            - name: Every hour (3600)
+              value: 3600
+            - name: Every 2 hours (7200)
+              value: 7200
+            - name: Every 3 hours (10800)
+              value: 10800
+            - name: Every 6 hours (21600)
+              value: 21600
+            - name: Every 12 hours (43200)
+              value: 43200
+            - name: Every 24 hours (86400)
+              value: 86400
+        - binding: baseline
+          name: Baseline ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+          description: |
+            The absolute minimum amount of ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} that the auction will trade at.
+
+            I.e. for each 1 ${order.outputs.0.token.symbol} sold you will receive at least this many ${order.inputs.0.token.symbol}.
+
+            I.e. this is calculated as the ${order.outputs.0.token.symbol} $ price divided by the ${order.inputs.0.token.symbol} $ price.
+            You can find $ prices for most tokens on dex tools, dex screener and gecko terminal.
+
+            For more information about IO ratios and how to calculate them see [Understanding IO Ratios](https://youtu.be/NdPOi1ZDnDk).
+        - binding: initial-io
+          name: Kickoff ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+          description: |
+            The initial ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol} to kickoff the first auction.
+
+            This ratio is calculated in the same way as the baseline ratio.
+
+            It must be greater than the baseline ratio, regardless of what you are selling or buying.
+            This is because getting more input per output is always better for you.
+            The initial auction will start high (at the value you set here) and then drop to the baseline ratio over time.
+            Subsequent auctions will start at some % above the last auction price and drop to the baseline ratio over time.
+        - binding: next-trade-multiplier
+          name: Auction start multiplier
+          description: |
+            The multiplier to apply to the last trade to kick off the next auction.
+          show-custom-field: true
+          default: 1.01
+          presets:
+            - name: 1.01x
+              value: 1.01
+            - name: 1.02x
+              value: 1.02
+            - name: 1.05x
+              value: 1.05
+            - name: 1.1x
+              value: 1.1
+        - binding: next-trade-baseline-multiplier
+          name: Auction end multiplier
+          description: |
+            The multiplier to apply to the last trade to set the baseline for the next auction.
+          show-custom-field: true
+          default: 0
+          presets:
+            - name: Disabled (0)
+              value: 0
+            - name: 0.7x
+              value: 0.7
+            - name: 0.8x
+              value: 0.8
+            - name: 0.9x
+              value: 0.9
+            - name: 0.95x
+              value: 0.95
+            - name: 0.99x
+              value: 0.99
+      select-tokens:
+        - key: output
+          name: Token to Sell
+          description: Select the token you want to sell
+        - key: input
+          name: Token to Buy
+          description: Select the token you want to purchase
+        
     polygon:
       name: Polygon
       description: Deploy an auction-based cost averaging strategy on Polygon.

--- a/src/auction-dca.rain
+++ b/src/auction-dca.rain
@@ -2,7 +2,7 @@ raindex-version: 8898591f3bcaa21dc91dc3b8584330fc405eadfa
 
 networks:
   arbitrum:
-    rpc: https://1rpc.io/arb
+    rpc: https://arbitrum-one-rpc.publicnode.com
     chain-id: 42161
     network-id: 42161
     currency: ETH
@@ -17,7 +17,7 @@ networks:
     network-id: 8453
     currency: ETH
   ethereum:
-    rpc: https://1rpc.io/eth
+    rpc: https://ethereum-rpc.publicnode.com
     chain-id: 1
     network-id: 1
     currency: ETH
@@ -27,7 +27,7 @@ networks:
     network-id: 14
     currency: FLR
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL

--- a/src/canary.rain
+++ b/src/canary.rain
@@ -7,7 +7,7 @@ networks:
     network-id: 8453
     currency: ETH
   arbitrum:
-    rpc: https://1rpc.io/arb
+    rpc: https://arbitrum-one-rpc.publicnode.com
     chain-id: 42161
     network-id: 42161
     currency: ETH
@@ -17,7 +17,7 @@ networks:
     network-id: 14
     currency: FLR
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL

--- a/src/dynamic-spread.rain
+++ b/src/dynamic-spread.rain
@@ -84,12 +84,12 @@ networks:
     network-id: 8453
     currency: ETH
   arbitrum:
-    rpc: https://1rpc.io/arb
+    rpc: https://arbitrum-one-rpc.publicnode.com
     chain-id: 42161
     network-id: 42161
     currency: ETH
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL
@@ -99,7 +99,7 @@ networks:
     network-id: 56
     currency: BNB
   ethereum:
-    rpc: https://1rpc.io/eth
+    rpc: https://ethereum-rpc.publicnode.com
     chain-id: 1
     network-id: 1
     currency: ETH

--- a/src/dynamic-spread.rain
+++ b/src/dynamic-spread.rain
@@ -11,6 +11,16 @@ scenarios:
       amount-token: ${order.inputs.0.token.address}
       initial-output-token: ${order.outputs.1.token.address}
       initial-input-token: ${order.inputs.0.token.address}
+  arbitrum2:
+    orderbook: arbitrum2
+    runs: 1
+    bindings:
+      raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
+      history-cap: '1e50'
+      shy-epoch: 0.05
+      amount-token: ${order.inputs.0.token.address}
+      initial-output-token: ${order.outputs.1.token.address}
+      initial-input-token: ${order.inputs.0.token.address}
   base:
     orderbook: base
     runs: 1
@@ -88,6 +98,11 @@ networks:
     chain-id: 42161
     network-id: 42161
     currency: ETH
+  arbitrum2:
+    rpc: https://arbitrum-one-rpc.publicnode.com
+    chain-id: 42161
+    network-id: 42161
+    currency: ETH
   polygon:
     rpc: https://polygon-rpc.com
     chain-id: 137
@@ -113,6 +128,7 @@ metaboards:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
+  arbitrum2: https://replaceme.com
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
   bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
@@ -122,6 +138,7 @@ subgraphs:
   flare: https://example.com/subgraph
   base: https://example.com/subgraph
   arbitrum: https://example.com/subgraph
+  arbitrum2: https://example.com/subgraph
   polygon: https://example.com/subgraph
   bsc: https://example.com/subgraph
   ethereum: https://example.com/subgraph
@@ -134,6 +151,8 @@ orderbooks:
     address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7
   arbitrum:
     address: 0x550878091b2B1506069F61ae59e3A5484Bca9166
+  arbitrum2:
+    address: 0x59401C9302E79Eb8AC6aea659B8B3ae475715e86
   polygon:
     address: 0x7D2f700b1f6FD75734824EA4578960747bdF269A
   bsc:
@@ -150,6 +169,8 @@ deployers:
     address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
   arbitrum:
     address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
+  arbitrum2:
+    address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
   polygon:
     address: 0xE7116BC05C8afe25e5B54b813A74F916B5D42aB1
   ethereum:
@@ -162,6 +183,14 @@ deployers:
 orders:
   arbitrum:
     orderbook: arbitrum
+    inputs:
+      - token: token1
+      - token: token2
+    outputs:
+      - token: token1
+      - token: token2
+  arbitrum2:
+    orderbook: arbitrum2
     inputs:
       - token: token1
       - token: token2
@@ -221,6 +250,9 @@ deployments:
   arbitrum:
     order: arbitrum
     scenario: arbitrum
+  arbitrum2:
+    order: arbitrum2
+    scenario: arbitrum2
   base:
     order: base
     scenario: base
@@ -246,6 +278,87 @@ gui:
   short-description: A market-making strategy that offers two-sided auction-based spreads that narrow over time, with a defensive feature that quickly exits positions by counter-trading when market trends emerge.
   deployments:
     arbitrum:
+      name: Arbitrum
+      description: Deploy a two-sided dynamic spread strategy on Arbitrum.
+      fields:
+        - binding: amount-is-fast-exit
+          name: Fast exit ${order.inputs.0.token.symbol}?
+          description: If enabled, the strategy will attempt to exit any ${order.inputs.0.token.symbol} position it builds up in a single trade, as soon as it can do so profitably.
+          presets:
+            - name: Yes
+              value: 1
+            - name: No
+              value: 0
+        - binding: not-amount-is-fast-exit
+          name: Fast exit ${order.inputs.1.token.symbol}?
+          description: If enabled, the strategy will attempt to exit any ${order.inputs.1.token.symbol} position it builds up in a single trade, as soon as it can do so profitably.
+          presets:
+            - name: Yes
+              value: 1
+            - name: No
+              value: 0
+        - binding: initial-io
+          name: Initial price (${order.inputs.0.token.symbol} per ${order.inputs.1.token.symbol})
+          description: This should be the ${order.inputs.0.token.symbol} price you see for ${order.inputs.1.token.symbol} on Dextools.
+        - binding: next-trade-multiplier
+          name: Next trade multiplier
+          description: This is the most the strategy will move the price in a single trade. Larger numbers will capture larger price jumps but trade less often, smaller numbers will trade more often but be less defensive against large price jumps in the market.
+          show-custom-field: true
+          default: 1.01
+          presets:
+            - name: 1.01x
+              value: 1.01
+            - name: 1.02x
+              value: 1.02
+            - name: 1.05x
+              value: 1.05
+        - binding: cost-basis-multiplier
+          name: Cost basis multiplier
+          description: The minimum spread applied to the breakeven in addition to the auction. This is applied in both directions so 1.01x would be a 2% total spread.
+          show-custom-field: true
+          default: 1
+          presets:
+            - name: 1 (auction spread only)
+              value: 1
+            - name: 1.0005x (0.1% total)
+              value: 1.0005
+            - name: 1.001x (0.2% total)
+              value: 1.001
+            - name: 1.0025x (0.5% total)
+              value: 1.0025
+            - name: 1.005x (1% total)
+              value: 1.005
+        - binding: time-per-epoch
+          name: Time per price halving (seconds)
+          description: The amount of time (in seconds) between halvings of the price and the amount offered during each auction, relative to their baselines.
+          show-custom-field: true
+          default: 3600
+          presets:
+            - name: 1 hour (3600)
+              value: 3600
+            - name: 2 hours (7200)
+              value: 7200
+            - name: 4 hours (14400)
+              value: 14400
+            - name: 8 hours (28800)
+              value: 28800
+        - binding: max-amount
+          name: Max amount
+          description: The maximum amount of ${order.inputs.0.token.symbol} that will be offered in a single auction.
+        - binding: min-amount
+          name: Minimum amount
+          description: The minimum amount of ${order.inputs.0.token.symbol} that will be offered in a single auction.
+      deposits:
+        - token: token1
+        - token: token2
+      select-tokens:
+        - key: token1
+          name: First token to rotate
+          description: Select the token you want to rotate. This will be the amount token that denominates trade sizes.
+        - key: token2
+          name: Second token to rotate
+          description: Select the token you want to rotate.
+    arbitrum2:
       name: Arbitrum
       description: Deploy a two-sided dynamic spread strategy on Arbitrum.
       fields:

--- a/src/fixed-limit.rain
+++ b/src/fixed-limit.rain
@@ -12,12 +12,12 @@ networks:
     network-id: 8453
     currency: ETH
   arbitrum:
-    rpc: https://1rpc.io/arb
+    rpc: https://arbitrum-one-rpc.publicnode.com
     chain-id: 42161
     network-id: 42161
     currency: ETH
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL
@@ -27,7 +27,7 @@ networks:
     network-id: 56
     currency: BNB
   ethereum:
-    rpc: https://1rpc.io/eth
+    rpc: https://ethereum-rpc.publicnode.com
     chain-id: 1
     network-id: 1
     currency: ETH

--- a/src/fixed-limit.rain
+++ b/src/fixed-limit.rain
@@ -16,6 +16,11 @@ networks:
     chain-id: 42161
     network-id: 42161
     currency: ETH
+  arbitrum2:
+    rpc: https://arbitrum-one-rpc.publicnode.com
+    chain-id: 42161
+    network-id: 42161
+    currency: ETH
   polygon:
     rpc: https://polygon-rpc.com
     chain-id: 137
@@ -41,6 +46,7 @@ metaboards:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
+  arbitrum2: https://example.com/subgraph
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
   bsc: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-bsc/0.1/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
@@ -50,6 +56,7 @@ subgraphs:
   flare: https://example.com/subgraph
   base: https://example.com/subgraph
   arbitrum: https://example.com/subgraph
+  arbitrum2: https://example.com/subgraph
   polygon: https://example.com/subgraph
   bsc: https://example.com/subgraph
   ethereum: https://example.com/subgraph
@@ -62,6 +69,8 @@ orderbooks:
     address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7
   arbitrum:
     address: 0x550878091b2B1506069F61ae59e3A5484Bca9166
+  arbitrum2:
+    address: 0x59401C9302E79Eb8AC6aea659B8B3ae475715e86
   polygon:
     address: 0x7D2f700b1f6FD75734824EA4578960747bdF269A
   bsc:
@@ -77,6 +86,8 @@ deployers:
   base:
     address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
   arbitrum:
+    address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
+  arbitrum2:
     address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
   polygon:
     address: 0xE7116BC05C8afe25e5B54b813A74F916B5D42aB1
@@ -102,6 +113,12 @@ orders:
       - token: token2
   arbitrum:
     orderbook: arbitrum
+    inputs:
+      - token: token1
+    outputs:
+      - token: token2
+  arbitrum2:
+    orderbook: arbitrum2
     inputs:
       - token: token1
     outputs:
@@ -134,6 +151,12 @@ orders:
 scenarios:
   arbitrum:
     orderbook: arbitrum
+    runs: 1
+    bindings:
+      raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
+      fixed-io-output-token: ${order.outputs.0.token.address}
+  arbitrum2:
+    orderbook: arbitrum2
     runs: 1
     bindings:
       raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
@@ -185,6 +208,9 @@ deployments:
   arbitrum:
     order: arbitrum
     scenario: arbitrum
+  arbitrum2:
+    order: arbitrum2
+    scenario: arbitrum2
   polygon:
     order: polygon
     scenario: polygon
@@ -284,6 +310,22 @@ gui:
           name: Token to Sell
           description: Select the token you want to sell
     arbitrum:
+      name: Arbitrum
+      description: Deploy a limit order on Arbitrum.
+      deposits:
+        - token: token2
+      fields:
+        - binding: fixed-io
+          name: ${order.inputs.0.token.symbol} per ${order.outputs.0.token.symbol}
+          description: Fixed exchange rate (${order.inputs.0.token.symbol} received per 1 ${order.outputs.0.token.symbol} sold)
+      select-tokens:
+        - key: token1
+          name: Token to Buy
+          description: Select the token you want to purchase
+        - key: token2
+          name: Token to Sell
+          description: Select the token you want to sell
+    arbitrum2:
       name: Arbitrum
       description: Deploy a limit order on Arbitrum.
       deposits:

--- a/src/folio.md
+++ b/src/folio.md
@@ -1,0 +1,3 @@
+# Folio Rebalancer
+
+Folio rebalances to equally weight every token in the folio.

--- a/src/folio.rain
+++ b/src/folio.rain
@@ -1,0 +1,128 @@
+version: 1
+
+networks:
+  arbitrum2:
+    rpc: https://arbitrum-one-rpc.publicnode.com
+    chain-id: 42161
+    network-id: 42161
+    currency: ETH
+
+metaboards:
+  arbitrum2: https://example.com/subgraph
+
+subgraphs:
+  arbitrum2: https://example.com/subgraph
+
+orderbooks:
+  arbitrum2:
+    address: 0x59401C9302E79Eb8AC6aea659B8B3ae475715e86
+
+deployers:
+  arbitrum2:
+    address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
+
+orders:
+  arbitrum2:
+    orderbook: arbitrum2
+    inputs:
+      - token: token1
+      - token: token2
+      - token: token3
+      - token: token4
+      - token: token5
+      - token: token6
+      - token: token7
+    outputs:
+      - token: token1
+      - token: token2
+      - token: token3
+      - token: token4
+      - token: token5
+      - token: token6
+      - token: token7
+
+scenarios:
+  arbitrum2:
+    orderbook: arbitrum2
+    runs: 1
+    bindings:
+      raindex-subparser: 0xb06202aA3Fe7d85171fB7aA5f17011d17E63f382
+
+deployments:
+  arbitrum2:
+    order: arbitrum2
+    scenario: arbitrum2
+
+gui:
+  name: Folio
+  description: Maintains an equal distribution of assets in a portfolio.
+  short-description: Rebalances a portfolio to maintain equal distribution of assets.
+  deployments:
+    arbitrum2:
+      name: Arbitrum
+      description: Rebalances a portfolio on the Arbitrum network.
+      deposits:
+        - token: token1
+        - token: token2
+        - token: token3
+        - token: token4
+        - token: token5
+        - token: token6
+        - token: token7
+      fields:
+        - binding: threshold
+          name: Threshold
+          description: The threshold for rebalancing the portfolio. E.g. 0.05 = 5%
+          type: number
+          default: 0.05
+        - binding: fee
+          name: Fee
+          description: The fee for rebalancing the portfolio. E.g. 0.003 = 0.3%
+          type: number
+          default: 0.003
+      select-tokens:
+        - key: token1
+          name: Token 1
+          description: The first token in the portfolio.
+        - key: token2
+          name: Token 2
+          description: The second token in the portfolio.
+        - key: token3
+          name: Token 3
+          description: The third token in the portfolio.
+        - key: token4
+          name: Token 4
+          description: The fourth token in the portfolio.
+        - key: token5
+          name: Token 5
+          description: The fifth token in the portfolio.
+        - key: token6
+          name: Token 6
+          description: The sixth token in the portfolio.
+        - key: token7
+          name: Token 7
+          description: The seventh token in the portfolio.
+
+---
+
+#raindex-subparser !The subparser to use.
+
+#threshold !The threshold for rebalancing the portfolio.
+#fee !The fee for rebalancing the portfolio.
+
+#spread !The spread for the portfolio on return of threshold.
+
+#calculate-io
+using-words-from raindex-subparser
+:ensure(every(input-vault-before() output-vault-before()) "zero balance"),
+base-io: div(input-vault-before() output-vault-before()),
+corrected-io: div(base-io sub(1 threshold)),
+feed-io: mul(corrected-io add(1 fee)),
+amount: mul(output-vault-before() threshold),
+io-ratio: feed-io;
+
+#handle-io
+:;
+
+#handle-add-order
+:;

--- a/src/grid.rain
+++ b/src/grid.rain
@@ -7,7 +7,7 @@ networks:
     network-id: 8453
     currency: ETH
   ethereum:
-    rpc: https://1rpc.io/eth
+    rpc: https://ethereum-rpc.publicnode.com
     chain-id: 1
     network-id: 1
     currency: ETH
@@ -17,7 +17,7 @@ networks:
     network-id: 56
     currency: BNB
   polygon:
-    rpc: https://1rpc.io/matic
+    rpc: https://polygon-rpc.com
     chain-id: 137
     network-id: 137
     currency: POL


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Replace 1rpc rpcs. See https://github.com/rainlanguage/rain.orderbook/issues/1886


## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated RPC endpoint URLs for Polygon, Arbitrum, Arbitrum2, and Ethereum networks across multiple configuration files to improve connectivity.
	- Added support for a new Arbitrum2 network with corresponding configurations and GUI deployment options.
	- Refreshed strategy file URLs in the registry to reference newer versions.
- **New Features**
	- Introduced a portfolio rebalancing feature ("Folio Rebalancer") with user-configurable parameters for threshold and fees, supporting equal token weighting on Arbitrum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->