### PR TITLE
Remove arbitrum2 network

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -105,9 +105,6 @@ deployers:
   arbitrum:
     address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
     network: arbitrum
-  arbitrum2:
-    address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
-    network: arbitrum
   bsc:
     address: 0xA2f56F8F74B7d04d61f281BE6576b6155581dcBA
     network: bsc

--- a/settings.yaml
+++ b/settings.yaml
@@ -23,12 +23,6 @@ networks:
     chain-id: 42161
     network-id: 42161
     currency: ETH
-  arbitrum2:
-    rpcs:
-      - https://arbitrum-one-rpc.publicnode.com
-    chain-id: 42161
-    network-id: 42161
-    currency: ETH
   bsc:
     rpcs:
       - https://bsc-dataseed.bnbchain.org
@@ -84,7 +78,7 @@ orderbooks:
     subgraph: arbitrum
   arbitrum2:
     address: 0xF6FdCB30FD027C73cBacD54E22f02987E3116eBc
-    network: arbitrum2
+    network: arbitrum
     subgraph: arbitrum2
   bsc:
     address: 0xd2938E7c9fe3597F78832CE780Feb61945c377d7
@@ -113,7 +107,7 @@ deployers:
     network: arbitrum
   arbitrum2:
     address: 0x9B0D254bd858208074De3d2DaF5af11b3D2F377F
-    network: arbitrum2
+    network: arbitrum
   bsc:
     address: 0xA2f56F8F74B7d04d61f281BE6576b6155581dcBA
     network: bsc


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the configuration for the `arbitrum2` network.
  * Updated references in orderbooks and deployers to use the `arbitrum` network instead of `arbitrum2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->