### PR TITLE
Bump versions to 5 and update metaboards mapping

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/1874f216cf22c469efc5ae5a4126d9d5a8602171/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 networks:
   base:
     rpcs:

--- a/settings.yaml
+++ b/settings.yaml
@@ -23,9 +23,15 @@ subgraphs:
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-matic/2025-09-23-7ac3/gn
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum-one/2025-09-18-da5d/gn
 metaboards:
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
-  polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
-  arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-arbitrum-one/2025-07-06-135f/gn
+  base:
+    address: 0x59401c9302e79eb8ac6aea659b8b3ae475715e86
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
+  polygon:
+    address: 0x0000000000000000000000000000000000000000
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
+  arbitrum:
+    address: 0x0000000000000000000000000000000000000000
+    url: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-arbitrum-one/2025-07-06-135f/gn
 orderbooks:
   base:
     address: 0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D

--- a/src/auction-dca.rain
+++ b/src/auction-dca.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orders:
   arbitrum:

--- a/src/canary.rain
+++ b/src/canary.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orderbooks:
   canary-arbitrum:

--- a/src/claims.rain
+++ b/src/claims.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orders:
   base:

--- a/src/dynamic-spread.rain
+++ b/src/dynamic-spread.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 scenarios:
   arbitrum:

--- a/src/fixed-limit.rain
+++ b/src/fixed-limit.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orderbooks:
   fixed-limit-arbitrum:

--- a/src/fixed-spread.rain
+++ b/src/fixed-spread.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orders:
   base:

--- a/src/folio.rain
+++ b/src/folio.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orders:
   base:

--- a/src/grid.rain
+++ b/src/grid.rain
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 
 orders:
   arbitrum:


### PR DESCRIPTION
## Motivation

Version bump for settings and all strategy files, along with updating the metaboards mapping to the new format that supports address and url fields.

## Solution

- Bumped version from 4 to 5 in `settings.yaml` and all 8 `.rain` strategy files
- Updated metaboards mapping to use `address` and `url` fields instead of a plain URL string
  - Base: `0x59401c9302e79eb8ac6aea659b8b3ae475715e86`
  - Polygon and Arbitrum: zero address
- Updated registry commit hash to point to the latest commit

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded system version from 4 to 5.
  * Updated all registry entries to reference new versioned base URLs.
  * Restructured metaboards configuration entries with enhanced address and URL fields for improved organization and network support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->