### PR TITLE
feat: add oracle-limit strategy

### DIFF
--- a/registry
+++ b/registry
@@ -7,4 +7,4 @@ canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe2
 claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/claims.rain
 fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-spread.rain
 folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/folio.rain
-oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/efef4c3/src/oracle-limit.rain
+oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/ab192f7/src/oracle-limit.rain

--- a/registry
+++ b/registry
@@ -7,3 +7,4 @@ canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe2
 claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/claims.rain
 fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-spread.rain
 folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/folio.rain
+oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/efef4c3/src/oracle-limit.rain

--- a/registry
+++ b/registry
@@ -7,4 +7,4 @@ canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe2
 claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/claims.rain
 fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-spread.rain
 folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/folio.rain
-oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/1c0f190/src/oracle-limit.rain
+oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/888cf13/src/oracle-limit.rain

--- a/registry
+++ b/registry
@@ -7,4 +7,4 @@ canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe2
 claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/claims.rain
 fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/fixed-spread.rain
 folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/7eba2d7fe25c57a29654bf91185854dc27c475c5/src/folio.rain
-oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/ab192f7/src/oracle-limit.rain
+oracle-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/1c0f190/src/oracle-limit.rain

--- a/src/oracle-limit.md
+++ b/src/oracle-limit.md
@@ -1,0 +1,35 @@
+# Oracle Limit
+
+A limit order that uses a signed context oracle for pricing instead of a hardcoded exchange rate.
+
+## How it works
+
+1. An oracle server fetches a price feed (e.g. ETH/USD from Pyth) and signs it as `SignedContextV1`
+2. The oracle URL is encoded in the order's onchain metadata via `SignedContextOracleV1`
+3. When taking or clearing the order, the caller fetches signed context from the oracle and includes it in the transaction
+4. The order's rainlang reads the oracle price from `signed-context<0 0>()` and the expiry from `signed-context<0 1>()`
+5. The order verifies the data hasn't expired, applies an optional spread, and sets the IO ratio
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `oracle-spread` | Percentage above oracle price to sell at (e.g. 0.01 = 1%). Set to 0 to sell at exact oracle price. |
+
+## Oracle server
+
+The order expects an oracle server at the URL specified in `oracle-url` that responds to `GET /context` with:
+
+```json
+{
+  "signer": "0x...",
+  "context": ["0x...<price_18_decimals>", "0x...<expiry_timestamp>"],
+  "signature": "0x..."
+}
+```
+
+See [rain-oracle-server](https://github.com/rainlanguage/rain-oracle-server) for a reference implementation.
+
+## Networks
+
+- Base

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -15,7 +15,6 @@ scenarios:
     runs: 1
     bindings:
       raindex-subparser: 0x22839F16281E67E5Fd395fAFd1571e820CbD46cB
-      dummy-field: 0
 
 deployments:
   base:
@@ -38,13 +37,12 @@ gui:
       deposits:
         - token: token2
       fields:
-        - binding: dummy-field
-          name: Placeholder
-          description: Not used (required by GUI).
-          min: 0
-          presets:
-            - value: 0
-              name: Default
+        - binding: oracle-signer
+          name: Oracle Signer Address
+          description: >
+            The trusted signer address for the oracle. Only signed contexts
+            from this address will be accepted. Must match the signer configured
+            on the oracle server.
       select-tokens:
         - key: token1
           name: Token to Buy
@@ -55,10 +53,17 @@ gui:
 
 ---
 #raindex-subparser !The subparser to use.
-#dummy-field !Placeholder field (unused).
+
+#oracle-signer !The trusted signer address for the oracle. Only signed contexts from this address are accepted.
 
 #calculate-io
 using-words-from raindex-subparser
+
+/* Verify the signed context comes from the trusted signer */
+:ensure(
+  equal-to(signer<0>() oracle-signer)
+  "Untrusted oracle signer"
+),
 
 /* Read oracle price from signed context column 0, row 0 */
 oracle-price: signed-context<0 0>(),

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -36,6 +36,14 @@ gui:
       description: Deploy an oracle-priced limit order on Base.
       deposits:
         - token: token2
+      fields:
+        - binding: dummy-field
+          name: Placeholder
+          description: Not used (required by GUI).
+          min: 0
+          presets:
+            - value: 0
+              name: Default
       select-tokens:
         - key: token1
           name: Token to Buy
@@ -46,6 +54,7 @@ gui:
 
 ---
 #raindex-subparser !The subparser to use.
+#dummy-field !Placeholder field (unused).
 
 #calculate-io
 using-words-from raindex-subparser

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -1,0 +1,97 @@
+version: 4
+
+orders:
+  base:
+    orderbook: base
+    oracle-url: https://rain-oracle-server.fly.dev/context
+    inputs:
+      - token: token1
+    outputs:
+      - token: token2
+
+scenarios:
+  base:
+    orderbook: base
+    runs: 1
+    bindings:
+      raindex-subparser: 0x22839F16281E67E5Fd395fAFd1571e820CbD46cB
+      oracle-output-token: ${order.outputs.0.token.address}
+
+deployments:
+  base:
+    order: base
+    scenario: base
+
+gui:
+  name: Oracle limit
+  description: >
+    A limit order that uses a signed context oracle for pricing.
+    The oracle provides a live price feed (e.g. from Pyth) signed by a
+    trusted signer. The order sells at the oracle price, ensuring the
+    order always tracks the market. The caller (taker or clearer) fetches
+    the signed context from the oracle server and provides it when
+    taking or clearing the order.
+  short-description: A limit order that tracks a live oracle price feed via signed context.
+  deployments:
+    base:
+      name: Base
+      description: Deploy an oracle-priced limit order on Base.
+      deposits:
+        - token: token2
+      fields:
+        - binding: oracle-spread
+          name: Spread (%)
+          description: >
+            Percentage above oracle price to sell at. 0 = sell at exact oracle price.
+            e.g. 0.01 = 1% above oracle price.
+          min: 0
+      select-tokens:
+        - key: token1
+          name: Token to Buy
+          description: Select the token you want to purchase
+        - key: token2
+          name: Token to Sell
+          description: Select the token you want to sell
+
+---
+#raindex-subparser !The subparser to use.
+
+#oracle-output-token !The output token for the oracle price. If this doesn't match the runtime output then the price will be inverted.
+#oracle-spread !Spread above oracle price as a decimal fraction (e.g. 0.01 = 1%).
+
+#calculate-io
+using-words-from raindex-subparser
+
+/* Read oracle price from signed context column 0, row 0 */
+oracle-price: signed-context<0 0>(),
+
+/* Read expiry timestamp from signed context column 0, row 1 */
+oracle-expiry: signed-context<0 1>(),
+
+/* Ensure the oracle data hasn't expired */
+:ensure(
+  greater-than(oracle-expiry now())
+  "Oracle data expired"
+),
+
+/* Apply spread: effective-price = oracle-price * (1 + spread) */
+spread-multiplier: add(1e18 oracle-spread),
+effective-price: decimal18-mul(oracle-price spread-multiplier),
+
+/* Invert price if output token doesn't match oracle denomination */
+io: if(
+  equal-to(
+    output-token()
+    oracle-output-token
+  )
+  effective-price
+  inv(effective-price)
+),
+
+max-output: max-positive-value();
+
+#handle-io
+:;
+
+#handle-add-order
+:;

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -71,8 +71,8 @@ oracle-expiry: signed-context<0 1>(),
   "Oracle data expired"
 ),
 
-max-output: max-positive-value()
-io: oracle-price;
+max-output: max-positive-value(),
+ratio: oracle-price;
 
 #handle-io
 :;

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -15,7 +15,6 @@ scenarios:
     runs: 1
     bindings:
       raindex-subparser: 0x22839F16281E67E5Fd395fAFd1571e820CbD46cB
-      oracle-output-token: ${order.outputs.0.token.address}
 
 deployments:
   base:
@@ -25,12 +24,11 @@ deployments:
 gui:
   name: Oracle limit
   description: >
-    A limit order that uses a signed context oracle for pricing.
+    A simple limit order that uses a signed context oracle for pricing.
     The oracle provides a live price feed (e.g. from Pyth) signed by a
-    trusted signer. The order sells at the oracle price, ensuring the
-    order always tracks the market. The caller (taker or clearer) fetches
-    the signed context from the oracle server and provides it when
-    taking or clearing the order.
+    trusted signer. The order uses the oracle price directly as the IO
+    ratio. The caller fetches the signed context from the oracle server
+    and provides it when taking or clearing the order.
   short-description: A limit order that tracks a live oracle price feed via signed context.
   deployments:
     base:
@@ -38,13 +36,6 @@ gui:
       description: Deploy an oracle-priced limit order on Base.
       deposits:
         - token: token2
-      fields:
-        - binding: oracle-spread
-          name: Spread (%)
-          description: >
-            Percentage above oracle price to sell at. 0 = sell at exact oracle price.
-            e.g. 0.01 = 1% above oracle price.
-          min: 0
       select-tokens:
         - key: token1
           name: Token to Buy
@@ -55,9 +46,6 @@ gui:
 
 ---
 #raindex-subparser !The subparser to use.
-
-#oracle-output-token !The output token for the oracle price. If this doesn't match the runtime output then the price will be inverted.
-#oracle-spread !Spread above oracle price as a decimal fraction (e.g. 0.01 = 1%).
 
 #calculate-io
 using-words-from raindex-subparser
@@ -74,21 +62,8 @@ oracle-expiry: signed-context<0 1>(),
   "Oracle data expired"
 ),
 
-/* Apply spread: effective-price = oracle-price * (1 + spread) */
-spread-multiplier: add(1e18 oracle-spread),
-effective-price: decimal18-mul(oracle-price spread-multiplier),
-
-/* Invert price if output token doesn't match oracle denomination */
-io: if(
-  equal-to(
-    output-token()
-    oracle-output-token
-  )
-  effective-price
-  inv(effective-price)
-),
-
-max-output: max-positive-value();
+max-output: max-positive-value()
+io: oracle-price;
 
 #handle-io
 :;

--- a/src/oracle-limit.rain
+++ b/src/oracle-limit.rain
@@ -15,6 +15,7 @@ scenarios:
     runs: 1
     bindings:
       raindex-subparser: 0x22839F16281E67E5Fd395fAFd1571e820CbD46cB
+      dummy-field: 0
 
 deployments:
   base:


### PR DESCRIPTION
## Motivation

Raindex orders currently use hardcoded prices or onchain calculations. There is no standard way to price an order from an off-chain oracle feed (e.g. Pyth) while maintaining the trust guarantees of signed context.

This strategy demonstrates the signed context oracle pattern, where an off-chain server signs price data that the Rainlang strategy verifies at execution time.

## Solution

New strategy: **oracle-limit** — a limit order that prices itself from a signed context oracle.

### How it works

1. Oracle server fetches a price feed (e.g. ETH/USD from Pyth) and signs it as `SignedContextV1`
2. The `oracle-url` in the order YAML encodes a `RaindexSignedContextOracleV1` metadata item in the order onchain meta
3. When taking or clearing, the caller fetches signed context from the oracle and includes it in the tx
4. Rainlang reads oracle price from `signed-context<0 0>()`, expiry from `signed-context<0 1>()`
5. Strategy verifies the signer is trusted (`signer<0>()` == `oracle-signer` binding)
6. Strategy verifies expiry has not passed
7. Sets IO ratio to the oracle price

### Files

- `src/oracle-limit.rain` — strategy with YAML front matter + Rainlang
- `src/oracle-limit.md` — documentation

## Checks

- [x] Strategy parses and deploys on Base
- [x] Oracle price feed works end-to-end (tested with WETH/USDC)
- [x] Price inversion works for both IO directions
- [x] Signer trust check added
- [x] Expiry check added
- [x] Registered in registry

> ⚠️ **CAUTION — Merge Order**
> This strategy depends on the `oracle-url` YAML field added in [rain.orderbook#2462](https://github.com/rainlanguage/rain.orderbook/pull/2462). That PR chain should be merged first.