### PR TITLE
Update raindex manifest URL

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/8b89c8343bed7717ae87450d793a0094f659aaa3/src/folio.rain

--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/2bf1d362c58a9a9be784133e2c5211912f8dbf2d/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -68,7 +68,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1776335970169/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Summary
- Update the raindex local DB manifest URL in settings.yaml to the timestamped manifest path.
- Update registry raw GitHub URLs to pin to the commit containing the settings change.

## Test plan
- Not run; config-only URL update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated external strategy repository references to point to a newer commit for all listed strategies.
  * Updated manifest configuration to reference versioned manifest paths for more stable, reproducible remotes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.strategies/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->