### PR TITLE
Rename gui keyword to builder across all strats

### DIFF
--- a/src/auction-dca.rain
+++ b/src/auction-dca.rain
@@ -85,7 +85,7 @@ deployments:
   base-pyth-inv:
     order: base
     scenario: pyth-price-baseline-base-inv
-gui:
+builder:
   name: Auction based cost averaging
   description: https://raw.githubusercontent.com/rainlanguage/rain.strategies/e25bc4876b5ffb8bb28097b0ca66de291c75ff56/src/auction-dca.md
   short-description:  >

--- a/src/canary.rain
+++ b/src/canary.rain
@@ -26,7 +26,7 @@ deployments:
   canary-arbitrum:
     order: canary-arbitrum
     scenario: canary-arbitrum
-gui:
+builder:
   name: Canary
   description: https://raw.githubusercontent.com/rainlanguage/rain.strategies/e25bc4876b5ffb8bb28097b0ca66de291c75ff56/src/canary.md
   short-description: Does nothing except give a bounty to the solver regularly.

--- a/src/claims.rain
+++ b/src/claims.rain
@@ -22,7 +22,7 @@ deployments:
     order: base
     scenario: base
 
-gui:
+builder:
   name: Claims
   description: Verifies merkle proofs against a set merkle root and distributes claims
   short-description: The order owner sets the merkle root at deploy time, the order taker then claims the output tokens by submitting the proof and the expected reward.

--- a/src/dynamic-spread.rain
+++ b/src/dynamic-spread.rain
@@ -66,7 +66,7 @@ deployments:
   polygon:
     order: polygon
     scenario: polygon
-gui:
+builder:
   name: Two-sided dynamic spread orders
   description: https://raw.githubusercontent.com/rainlanguage/rain.strategies/e25bc4876b5ffb8bb28097b0ca66de291c75ff56/src/dynamic-spread.md
   short-description: A market-making order that offers two-sided auction-based spreads that narrow over time, with a defensive feature that quickly exits positions by counter-trading when market trends emerge.

--- a/src/fixed-limit.rain
+++ b/src/fixed-limit.rain
@@ -57,7 +57,7 @@ deployments:
   polygon:
     order: polygon
     scenario: polygon
-gui:
+builder:
   name: Fixed limit
   description: A very simple order that places a limit order at a fixed price.
   short-description: A very simple order that places a limit order at a fixed price.

--- a/src/fixed-spread.rain
+++ b/src/fixed-spread.rain
@@ -36,7 +36,7 @@ deployments:
     scenario: pyth-price-baseline-base-inv
 
 
-gui:
+builder:
   name: Pyth fixed spread limit
   description: https://raw.githubusercontent.com/rainlanguage/rain.strategies/e25bc4876b5ffb8bb28097b0ca66de291c75ff56/src/fixed-spread.md
   short-description:  >

--- a/src/folio.rain
+++ b/src/folio.rain
@@ -32,7 +32,7 @@ deployments:
     order: base
     scenario: base
 
-gui:
+builder:
   name: Folio
   description: Maintains an equal distribution of assets in a portfolio.
   short-description: Rebalances a portfolio to maintain equal distribution of assets.

--- a/src/grid.rain
+++ b/src/grid.rain
@@ -18,7 +18,7 @@ deployments:
   arbitrum:
     order: arbitrum
     scenario: arbitrum
-gui:
+builder:
   name: Grid
   description: https://raw.githubusercontent.com/rainlanguage/rain.strategies/e25bc4876b5ffb8bb28097b0ca66de291c75ff56/src/grid.md
   short-description: Places automated orders at fixed price intervals with optional automatic refilling over time.


### PR DESCRIPTION
Re-applies the gui → builder keyword rename from the \`rename-gui-to-builder\` branch (originally \`7f4cbd6\` by @anakisci) on top of current main (which already has v6 + \`raindexes:\` from #96), so the combined registry content is v6 + raindexes: + builder: — what \`@rainlanguage/raindex\` main currently expects.

## Context

The \`rename-gui-to-builder\` branch later downgraded itself back to v5 + \`orderbooks:\` (commits cd1efb1, 2130363) to keep working against an older raindex, which is why the existing pin still points there. With raindex's rename PR (rainlanguage/raindex#2526) about to land, the registry needs the v6+raindexes+builder combination, and this branch produces exactly that without the downgrades.

## CI note

rain.strategies' own CI tests YAML against \`@rainlanguage/raindex\` main. Until raindex#2526 lands, raindex main parses v5+\`orderbooks:\`, so CI will fail with version-mismatch errors. That's expected — the loop breaks here. Once raindex#2526 merges:
1. raindex main supports v6+raindexes+builder
2. raindex#2526's REGISTRY_URL bumps to point at this commit
3. Both repos go green

## Verification

grep -E '^(version|raindexes|orderbooks|builder|gui):' src/fixed-limit.rain returns:
- version: 6
- raindexes:
- builder:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration section naming across multiple modules to align with internal naming standards without affecting core functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.strategies/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->