### PR TITLE
Bump registry hashes to gui-to-builder commit

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/888c3bda115b5bca325afc013629623c95620cc5/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/342ee3c75f390318481e9ca0367aad9311bee9e2/src/folio.rain


### PR DESCRIPTION
Follow-up to #105 (merged at 342ee3c). The registry files per-strategy URLs still pointed at 888c3bda1 (the prior commit, which has gui:), so consumers fetching the registry got the gui-keyed .rain files even after the rename merge. Bumps the per-strategy URLs to 342ee3c so the registry serves the builder-keyed content.

Same circular-CI caveat as #105: rainlanguage/raindex main parses v5+orderbooks, so this PR's CI will fail until rainlanguage/raindex#2526 lands. Admin-merge expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry to reference latest strategy definitions, including settings configuration and all strategy modules (fixed-limit, auction-dca, grid, dynamic-spread, canary, claims, fixed-spread, folio).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.strategies/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->