### PR TITLE
Local DB producer settings - derived vault deltas

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/9bed89b2f666f2135c5aac0c5dfe9d48c54b8c5a/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779638167599/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779707978613/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
# DO NOT CLOSE/MERGE THIS PR

This PR is needed in order for the remote db syncing to work.

This settings change points the local DB remote manifest at the manifest generated for rainlanguage/raindex#2592, which materializes vault deltas for balance sync.

Related raindex PR: https://app.graphite.com/github/pr/rainlanguage/raindex/2592

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)