### PR TITLE
Update website manifest for new database schema

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1776335970169/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779707978613/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Motivation

This updates the website settings to use the new database schema manifest.

## Solution

Point `local-db-remotes.raindex` at the new manifest URL:

https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779707978613/manifest.yaml

The registry URLs were also updated to point at the settings commit that contains the manifest change.

## Checks

- Verified the manifest URL resolves and reports schema version 4 with a Base dump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry resource references to align with the latest upstream versions across all strategy entries.
  * Updated manifest configuration identifier for improved resource tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.strategies/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->