### PR TITLE
Update website manifest for derived trades schema

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4ec2d7dddc955f732213f6ac9145e02b84186a7/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/b1584c7147012344c8b529f34b3e8c376377d096/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1776335970169/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779638167599/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Motivation

This updates the website settings to use the manifest generated for the derived trades local DB read model.

Related raindex PR: https://app.graphite.com/github/pr/rainlanguage/raindex/2587

## Solution

Point `local-db-remotes.raindex` at the derived trades manifest URL:

https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779638167599/manifest.yaml

The registry URLs were also updated to point at the settings commit that contains the manifest change.

## Checks

- Verified the manifest URL resolves and reports schema version 4 with a Base dump.
