### PR TITLE
Update website manifest for derived vault deltas schema v5

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/160aa1338b8449dbe5ea96392e3e1bbd728fe83b/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779707978613/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779812963870/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Motivation

This updates the website settings to use the schema v5 manifest for the derived vault deltas stack.

## Solution

Point `local-db-remotes.raindex` at the new manifest URL:

https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779812963870/manifest.yaml

The registry URLs were also updated to point at the settings commit that contains the manifest change.

## Checks

- Verified the manifest URL resolves and reports schema version 5 with a Base dump.
