### PR TITLE
Update website manifest for schema v5

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/832b9f35c2ca8e38a82cf860b2fc478c0ebb66bd/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/a416ecb9c926357afd547765bfe326ea121c8cf2/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779707978613/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779812963870/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Motivation

This updates the website settings to use the schema v5 local DB manifest.

## Solution

Point `local-db-remotes.raindex` at the new manifest URL:

https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779812963870/manifest.yaml

The registry URLs were also updated to point at the settings commit that contains the manifest change.

## Checks

- Verified the manifest URL resolves and reports schema version 5 with a Base dump.
- `cargo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry entries and configuration references to reflect newer upstream versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.strategies/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->