### PR TITLE
Fix vault balance manifest

### DIFF
--- a/registry
+++ b/registry
@@ -1,9 +1,9 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/settings.yaml
-fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/auction-dca.rain
-grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/dynamic-spread.rain
-canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/canary.rain
-claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/claims.rain
-fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/fixed-spread.rain
-folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/70c481ead025d274e3754158da96c4c91405ecf7/src/folio.rain
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/settings.yaml
+fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/fixed-limit.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/auction-dca.rain
+grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/grid.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/dynamic-spread.rain
+canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/canary.rain
+claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/claims.rain
+fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/fixed-spread.rain
+folio https://raw.githubusercontent.com/rainlanguage/rain.strategies/a4b6978bddf921b34efad837ae04171defebfc27/src/folio.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,7 +34,7 @@ using-tokens-from:
   - https://tokens.coingecko.com/base/all.json
 
 local-db-remotes:
-  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779812963870/manifest.yaml
+  raindex: https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779881382550/manifest.yaml
 
 local-db-sync:
   base:


### PR DESCRIPTION
## Motivation

This updates the local DB bootstrap manifest used by the website to fix the vault balance issue.

## Solution

Point `local-db-remotes.raindex` at the new manifest URL:

https://raindex-bootstrap-db.lon1.digitaloceanspaces.com/local-db-manifests/1779881382550/manifest.yaml

Update every `registry` URL pin to the settings content commit that contains the manifest change.

## Checks

- Verified the manifest URL resolves.
- Confirmed the manifest reports `manifest-version: 1` and `db-schema-version: 5`.
