### PR TITLE
Clamp dynamic-spread halflife exponent to 192

### DIFF
--- a/registry
+++ b/registry
@@ -2,7 +2,7 @@ https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b04941627
 fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/fixed-limit.rain
 auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/auction-dca.rain
 grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/grid.rain
-dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/dynamic-spread.rain
+dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/29a781d772099255465a17f043be8b11ea671f5f/src/dynamic-spread.rain
 canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/canary.rain
 claims https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/claims.rain
 fixed-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/fixed-spread.rain

--- a/src/dynamic-spread.rain
+++ b/src/dynamic-spread.rain
@@ -182,7 +182,12 @@ builder:
 
 #halflife
 epoch:,
-val: power(0.5 epoch);
+/* The exponent is clamped to 192 because power(0.5 x) reverts with
+PRBMath_UD60x18_Exp2_InputTooBig once x exceeds 192. At an exponent of
+192 the decay multiplier 0.5^192 is already ~1.6e-58, i.e. effectively
+zero, so clamping leaves the decay fully saturated rather than reverting
+for any longer-running auction. */
+val: power(0.5 min(epoch 192));
 
 #set-last-trade
 last-io:,


### PR DESCRIPTION
## Problem

The dynamic-spread (DSF) strategy reverts with `PRBMath_UD60x18_Exp2_InputTooBig(uint256)` once the decay exponent exceeds 192.

`#halflife` computed `power(0.5 epoch)` directly, where `epoch = duration / time-per-epoch` grows unbounded as a position sits without trading. The deployed interpreter computes `pow(0.5, e)` as `exp2(log2(2) * e) = exp2(e)`, and PRBMath's `exp2` reverts when its input strictly exceeds `192e18`. So any `epoch > 192` reverts the whole quote.

Repro from #44 (live Polygon orders that hit this):

```
now : 1750847987
last-trade-time: 1734415294
duration :  16432689
epochs: 16432689 / 7200 = 2282.31...
decay-multiplier : 0.5 ^ 2282... -> reverts (exp2 input > 192)
```

## Fix

`src/dynamic-spread.rain`, `#halflife` (lines 183-190): clamp the exponent with `min`:

```
val: power(0.5 min(epoch 192));
```

`0.5 ^ 192 ≈ 1.6e-58`, i.e. the decay multiplier is already effectively zero at the clamp point, so a longer-running auction degrades gracefully to a fully-saturated decay (the auction component collapses to its baseline/minimum) instead of reverting. Behaviour for `epoch <= 192` is unchanged. The boundary is safe: PRBMath `exp2` reverts only on input *strictly greater than* `192e18`, so `pow(0.5, 192)` -> `exp2(192e18)` does not revert.

This matches the maintainer's suggested approach in the issue (`min(192 ...)`).

The `registry` `dynamic-spread` URL is repointed at the content commit per the repo's registry workflow.

## Testing

- `nix develop -c rainix-rs-static` — green (fmt + clippy clean).
- `nix develop -c rainix-rs-test` — green (`all_rpcs_support_eth_call` passes); this is the repo's only test, on `main` before the change too.

Note: this repo's harness (`tests/rpc.rs` via `raindex_app_settings`) only validates settings YAML + RPC endpoints; its dependency tree and dev shell carry no rainlang interpreter / forker / `compose`-to-bytecode capability (no `rain`/`dotrain` CLI, only `forge`). A test that actually evaluates the `power(0.5 ...)` clamp through an EVM would require adding the upstream eval stack (`rainlang-eval` + `FuzzRunner` + a `LocalEvm`/anvil or live RPC), which this settings-only repo deliberately does not carry — out of scope for this fix. The clamp's correctness is established analytically above against the deployed PRBMath `exp2` bound.

A sibling strategy, `src/auction-dca.rain`, has the same unbounded `#halflife epoch:, val: power(0.5 epoch);` pattern and would revert identically for large epochs; left untouched here since #44 is scoped to DSF, but worth a follow-up.

Closes #44