### PR TITLE
fix(auction-dca): clamp halflife exponent to 192 (prevent PRBMath exp2 revert DoS)

### DIFF
--- a/registry
+++ b/registry
@@ -1,6 +1,6 @@
 https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/settings.yaml
 fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/fixed-limit.rain
-auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/auction-dca.rain
+auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/5b4b2aeef718fdc966cac279308ae44495202ae9/src/auction-dca.rain
 grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/grid.rain
 dynamic-spread https://raw.githubusercontent.com/rainlanguage/rain.strategies/29a781d772099255465a17f043be8b11ea671f5f/src/dynamic-spread.rain
 canary https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/canary.rain

--- a/src/auction-dca.rain
+++ b/src/auction-dca.rain
@@ -491,7 +491,12 @@ capped-unused: min(unused target-amount);
 
 #halflife
 epoch:,
-val: power(0.5 epoch);
+/* The exponent is clamped to 192 because power(0.5 x) reverts with
+PRBMath_UD60x18_Exp2_InputTooBig once x exceeds 192. At an exponent of
+192 the decay multiplier 0.5^192 is already ~1.6e-58, i.e. effectively
+zero, so clamping leaves the decay fully saturated rather than reverting
+for any longer-running auction. */
+val: power(0.5 min(epoch 192));
 
 #io-for-epoch
 epoch:,


### PR DESCRIPTION
## Problem

`src/auction-dca.rain` has the **same unbounded-`#halflife` bug** that PR #118 just fixed in `dynamic-spread`. PR #118 explicitly flagged auction-dca as a follow-up ("A sibling strategy, `src/auction-dca.rain`, has the same unbounded `#halflife epoch:, val: power(0.5 epoch);` pattern and would revert identically for large epochs"). This is that follow-up.

The `#halflife` binding (line ~494) computes:

```
val: power(0.5 epoch);
```

with an **unbounded, time-derived** `epoch` (`trade-epochs = elapsed-seconds / time-per-trade-epoch`, floored at 0 but never capped). `power(0.5 x)` is PRBMath UD60x18 `exp2(x)`, which **reverts** with `PRBMath_UD60x18_Exp2_InputTooBig` once `x` strictly exceeds 192.

An idle / un-cleared order crosses epoch 192 after `~192 * time-per-trade-epoch` seconds:
- ~192 * 3600s ≈ **8 days** at the default `time-per-trade-epoch = 3600s`
- ≈ **2.67 days** at the 1200s preset

Once that threshold is passed, the next `calculate-io` evaluation unconditionally calls `#halflife` — via **both** `#amount-for-epoch` (line ~486) and `#io-for-epoch` (line ~503) — so it reverts. The order can then never be quoted or cleared again: **permanent DoS**. `set-last-trade` (which would reset the duration and rescue the order) runs only *after* the `#halflife` call, so the revert blocks any recovery.

## Fix

Mirror #118 exactly. Clamp the single shared `#halflife` exponent with `min(... 192)`:

```
val: power(0.5 min(epoch 192));
```

`0.5 ^ 192 ≈ 1.6e-58` — the decay multiplier is already effectively zero at the clamp point, so a longer-running auction degrades gracefully to a fully-saturated decay (the auction component collapses to its baseline/minimum) instead of reverting. Behaviour for `epoch <= 192` is unchanged. The boundary is safe: PRBMath `exp2` reverts only on input *strictly greater than* `192e18`, so `pow(0.5, 192)` -> `exp2(192e18)` does not revert.

This one `#halflife` binding is shared by both call sites (`#amount-for-epoch` and `#io-for-epoch`), so the single change covers the whole strategy. The clamp comment is copied verbatim from the merged #118 dynamic-spread fix.

The `registry` `auction-dca` URL is repointed at the content commit per the repo's registry workflow (same two-step #118 used for `dynamic-spread`).

## Testing

This repo's harness (`tests/rpc.rs` via `raindex_app_settings`) only validates settings YAML + RPC endpoints; its dependency tree and dev shell carry no rainlang interpreter / forker / `compose`-to-bytecode capability, so it cannot evaluate the `power(0.5 ...)` clamp through an EVM (same situation #118 documented). The clamp's correctness is established analytically against the deployed PRBMath `exp2` bound, identical to #118.

Verified by grep: `power(0.5 epoch)` no longer appears in `src/auction-dca.rain`; `power(0.5 min(epoch 192))` does.

Mirrors #118.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auction-dca strategy decay computation has been enhanced to handle extended auction durations without errors. The optimization ensures stable and reliable operation during long-running auctions, preventing failures that could occur in extended operation scenarios.

* **Updates**
  * Auction-dca strategy registry reference updated to the latest remote version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->