### PR TITLE
Update Base raindex to inventory deployment address

### DIFF
--- a/registry
+++ b/registry
@@ -1,4 +1,4 @@
-https://raw.githubusercontent.com/rainlanguage/rain.strategies/c3093fe667cc2ea5a1e6f6b264f3d5e37a4bab23/settings.yaml
+https://raw.githubusercontent.com/rainlanguage/rain.strategies/bbed4c01f3157213567789878f4a63c03a2fab89/settings.yaml
 fixed-limit https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/fixed-limit.rain
 auction-dca https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/auction-dca.rain
 grid https://raw.githubusercontent.com/rainlanguage/rain.strategies/95f6c246b049416275762d8f4008ca8ed445b034/src/grid.rain

--- a/settings.yaml
+++ b/settings.yaml
@@ -15,10 +15,10 @@ metaboards:
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
 raindexes:
   base:
-    address: 0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D
+    address: 0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2
     network: base
     subgraph: base
-    deployment-block: 41747644
+    deployment-block: 48715479
     local-db-remote: raindex
 rainlangs:
   base:


### PR DESCRIPTION
## Summary

- Updates `raindexes.base.address` in `settings.yaml` to the new Raindex inventory contract on Base: `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2`
- Updates `deployment-block` to `48715479` to match the new deployment
- Pins the updated `settings.yaml` in `registry`

## Test plan

- [ ] Verify `settings.yaml` loads and resolves the new raindex address on Base
- [ ] Confirm local DB sync starts from deployment block `48715479`
- [ ] Smoke-test strategy deployment against the inventory raindex contract


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the registry settings source to a newer upstream revision.
  * Updated the Base network raindex contract address and deployment block.
  * All other configured strategy entries and network references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->